### PR TITLE
PSR-1482 Resolve TODO for PSR connector

### DIFF
--- a/app/uk/gov/hmrc/pensionschemereturn/connectors/PsrConnector.scala
+++ b/app/uk/gov/hmrc/pensionschemereturn/connectors/PsrConnector.scala
@@ -164,8 +164,7 @@ class PsrConnector @Inject()(config: AppConfig, http: HttpClientV2, apiAuditUtil
           case OK =>
             response.json.as[Seq[PsrVersionsEtmpResponse]]
           case SERVICE_UNAVAILABLE =>
-            // TODO - must be a temporary solution to check QA env issues
-            logger.info(s"$logMessage and returned status ${response.status} - returning empty response")
+            logger.warn(s"$logMessage and returned status ${response.status} - returning empty response")
             Seq.empty[PsrVersionsEtmpResponse]
           case NOT_FOUND =>
             logger.info(s"$logMessage and returned status ${response.status}")

--- a/app/uk/gov/hmrc/pensionschemereturn/utils/HttpResponseHelper.scala
+++ b/app/uk/gov/hmrc/pensionschemereturn/utils/HttpResponseHelper.scala
@@ -50,7 +50,7 @@ trait HttpResponseHelper extends HttpErrorFunctions {
         throw UpstreamErrorResponse(
           upstreamResponseMessage(httpMethod, url, status, response.body),
           status,
-          BAD_GATEWAY
+          status
         )
       case _ =>
         throw new UnrecognisedHttpResponseException(httpMethod, url, response)

--- a/it/test/uk/gov/hmrc/pensionschemereturn/connectors/SchemeDetailsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/pensionschemereturn/connectors/SchemeDetailsConnectorSpec.scala
@@ -33,10 +33,9 @@ import uk.gov.hmrc.pensionschemereturn.models.Srn
 import utils.TestValues
 import play.api.test.Helpers.defaultAwaitTimeout
 
-
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class SchemeDetailsConnectorSpec extends BaseConnectorSpec with TestValues{
+class SchemeDetailsConnectorSpec extends BaseConnectorSpec with TestValues {
 
   private implicit lazy val hc: HeaderCarrier = HeaderCarrier()
 
@@ -47,8 +46,7 @@ class SchemeDetailsConnectorSpec extends BaseConnectorSpec with TestValues{
   object CheckAssociationHelper {
     val url = "/pensions-scheme/is-psa-associated"
 
-    def stubGet(idValue: String, idType: String, srn: String, response: ResponseDefinitionBuilder): StubMapping = {
-
+    def stubGet(idValue: String, idType: String, srn: String, response: ResponseDefinitionBuilder): StubMapping =
       wireMockServer
         .stubFor(
           get(urlEqualTo(url))
@@ -57,7 +55,6 @@ class SchemeDetailsConnectorSpec extends BaseConnectorSpec with TestValues{
             .withHeader("Content-Type", equalTo("application/json"))
             .willReturn(response)
         )
-    }
   }
 
   private lazy val connector: SchemeDetailsConnector = app.injector.instanceOf[SchemeDetailsConnector]
@@ -66,60 +63,56 @@ class SchemeDetailsConnectorSpec extends BaseConnectorSpec with TestValues{
     "return true if psa is associated" in {
       CheckAssociationHelper.stubGet(psaId, Constants.psaId, srn, ok("true"))
 
-      whenReady(connector.checkAssociation(psaId, Constants.psaId, Srn(srn).get)) {
-        result: Boolean =>
-          WireMock.verify(
-            getRequestedFor(urlEqualTo("/pensions-scheme/is-psa-associated"))
-              .withHeader(Constants.psaId, equalTo(psaId))
-              .withHeader("schemeReferenceNumber", equalTo(srn))
-              .withHeader("Content-Type", equalTo("application/json"))
-          )
-          result shouldMatchTo true
+      whenReady(connector.checkAssociation(psaId, Constants.psaId, Srn(srn).get)) { result: Boolean =>
+        WireMock.verify(
+          getRequestedFor(urlEqualTo("/pensions-scheme/is-psa-associated"))
+            .withHeader(Constants.psaId, equalTo(psaId))
+            .withHeader("schemeReferenceNumber", equalTo(srn))
+            .withHeader("Content-Type", equalTo("application/json"))
+        )
+        result shouldMatchTo true
       }
     }
 
     "return false if psa is not associated" in {
       CheckAssociationHelper.stubGet(psaId, Constants.psaId, srn, ok("false"))
 
-      whenReady(connector.checkAssociation(psaId, Constants.psaId, Srn(srn).get)) {
-        result: Boolean =>
-          WireMock.verify(
-            getRequestedFor(urlEqualTo("/pensions-scheme/is-psa-associated"))
-              .withHeader(Constants.psaId, equalTo(psaId))
-              .withHeader("schemeReferenceNumber", equalTo(srn))
-              .withHeader("Content-Type", equalTo("application/json"))
-          )
-          result shouldMatchTo false
+      whenReady(connector.checkAssociation(psaId, Constants.psaId, Srn(srn).get)) { result: Boolean =>
+        WireMock.verify(
+          getRequestedFor(urlEqualTo("/pensions-scheme/is-psa-associated"))
+            .withHeader(Constants.psaId, equalTo(psaId))
+            .withHeader("schemeReferenceNumber", equalTo(srn))
+            .withHeader("Content-Type", equalTo("application/json"))
+        )
+        result shouldMatchTo false
       }
     }
 
     "return true if psp is associated" in {
       CheckAssociationHelper.stubGet(pspId, Constants.pspId, srn, ok("true"))
 
-      whenReady(connector.checkAssociation(pspId, Constants.pspId, Srn(srn).get)) {
-        result: Boolean =>
-          WireMock.verify(
-            getRequestedFor(urlEqualTo("/pensions-scheme/is-psa-associated"))
-              .withHeader(Constants.pspId, equalTo(pspId))
-              .withHeader("schemeReferenceNumber", equalTo(srn))
-              .withHeader("Content-Type", equalTo("application/json"))
-          )
-          result shouldMatchTo true
+      whenReady(connector.checkAssociation(pspId, Constants.pspId, Srn(srn).get)) { result: Boolean =>
+        WireMock.verify(
+          getRequestedFor(urlEqualTo("/pensions-scheme/is-psa-associated"))
+            .withHeader(Constants.pspId, equalTo(pspId))
+            .withHeader("schemeReferenceNumber", equalTo(srn))
+            .withHeader("Content-Type", equalTo("application/json"))
+        )
+        result shouldMatchTo true
       }
     }
 
     "return false if psp is not associated" in {
       CheckAssociationHelper.stubGet(pspId, Constants.pspId, srn, ok("false"))
 
-      whenReady(connector.checkAssociation(pspId, Constants.pspId, Srn(srn).get)) {
-        result: Boolean =>
-          WireMock.verify(
-            getRequestedFor(urlEqualTo("/pensions-scheme/is-psa-associated"))
-              .withHeader(Constants.pspId, equalTo(pspId))
-              .withHeader("schemeReferenceNumber", equalTo(srn))
-              .withHeader("Content-Type", equalTo("application/json"))
-          )
-          result shouldMatchTo false
+      whenReady(connector.checkAssociation(pspId, Constants.pspId, Srn(srn).get)) { result: Boolean =>
+        WireMock.verify(
+          getRequestedFor(urlEqualTo("/pensions-scheme/is-psa-associated"))
+            .withHeader(Constants.pspId, equalTo(pspId))
+            .withHeader("schemeReferenceNumber", equalTo(srn))
+            .withHeader("Content-Type", equalTo("application/json"))
+        )
+        result shouldMatchTo false
       }
     }
 

--- a/test/resources/PSR with Login/Email callback - PSA.bru
+++ b/test/resources/PSR with Login/Email callback - PSA.bru
@@ -1,7 +1,7 @@
 meta {
   name: Email callback - PSA
   type: http
-  seq: 38
+  seq: 15
 }
 
 post {

--- a/test/resources/PSR with Login/Email callback - PSP.bru
+++ b/test/resources/PSR with Login/Email callback - PSP.bru
@@ -1,7 +1,7 @@
 meta {
   name: Email callback - PSP
   type: http
-  seq: 39
+  seq: 16
 }
 
 post {

--- a/test/resources/PSR with Login/Overview - Missing date.bru
+++ b/test/resources/PSR with Login/Overview - Missing date.bru
@@ -1,7 +1,7 @@
 meta {
   name: Overview - Missing date
   type: http
-  seq: 30
+  seq: 17
 }
 
 get {

--- a/test/resources/PSR with Login/Versions - Bad request.bru
+++ b/test/resources/PSR with Login/Versions - Bad request.bru
@@ -1,7 +1,7 @@
 meta {
   name: Versions - Bad request
   type: http
-  seq: 35
+  seq: 19
 }
 
 get {

--- a/test/resources/PSR with Login/Versions - Empty on 503.bru
+++ b/test/resources/PSR with Login/Versions - Empty on 503.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Versions - Empty on 503
+  type: http
+  seq: 20
+}
+
+get {
+  url: {{pension-scheme-return}}/psr/versions/24000001IN?startDate=2018-04-06
+  body: none
+  auth: bearer
+}
+
+query {
+  startDate: 2018-04-06
+}
+
+headers {
+  srn: S0000000042
+}
+
+auth:bearer {
+  token: {{bearer_token}}
+}
+
+tests {
+  test("Status code is 503", function () {
+      expect(res.getStatus()).to.equal(203);
+  });
+}

--- a/test/resources/PSR with Login/Versions - OK.bru
+++ b/test/resources/PSR with Login/Versions - OK.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Versions - OK
+  type: http
+  seq: 18
+}
+
+get {
+  url: {{pension-scheme-return}}/psr/versions/24000001IN?startDate=2021-04-06
+  body: none
+  auth: bearer
+}
+
+query {
+  startDate: 2021-04-06
+}
+
+headers {
+  srn: S0000000042
+}
+
+auth:bearer {
+  token: {{bearer_token}}
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/test/resources/PSR with Login/Versions for years - Including 2018 with 503.bru
+++ b/test/resources/PSR with Login/Versions for years - Including 2018 with 503.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Versions for years - Including 2018 with 503
+  type: http
+  seq: 23
+}
+
+get {
+  url: {{pension-scheme-return}}/psr/versions/years/24000001IN?startDates=2018-04-06&startDates=2019-04-06
+  body: none
+  auth: bearer
+}
+
+query {
+  startDates: 2018-04-06
+  startDates: 2019-04-06
+}
+
+headers {
+  srn: S0000000042
+}
+
+auth:bearer {
+  token: {{bearer_token}}
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/test/resources/PSR with Login/Versions for years - OK.bru
+++ b/test/resources/PSR with Login/Versions for years - OK.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Versions for years - OK
+  type: http
+  seq: 21
+}
+
+get {
+  url: {{pension-scheme-return}}/psr/versions/years/24000001IN?startDates=2021-04-06&startDates=2022-04-06&startDates=2023-04-06
+  body: none
+  auth: bearer
+}
+
+query {
+  startDates: 2021-04-06
+  startDates: 2022-04-06
+  startDates: 2023-04-06
+}
+
+headers {
+  srn: S0000000042
+}
+
+auth:bearer {
+  token: {{bearer_token}}
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}


### PR DESCRIPTION
Logic of PSRConnector remains the same, however  HttpResponseHelper now returns the actual http code in case of 5xx responses instead of defaulting to BAD_GATEWAY.
Bruno calls added for combination of 200/503 responses in versions calls.